### PR TITLE
Fix android opening uber app when select google map option

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ export function generatePrefixes(options) {
 export function prefixForGoogleMaps(alwaysIncludeGoogle) {
   return isIOS && !alwaysIncludeGoogle
     ? 'comgooglemaps://'
-    : 'https://maps.google.com/';
+    : (isIOS && alwaysIncludeGoogle ? 'https://maps.google.com/' : 'geo:');
 }
 
 export function generateTitles(titles) {


### PR DESCRIPTION
Hello guys, i'm using this lib in my company application but i found a strange behavior, i spend two days trying to found a best solution and this PR contains the best i got, be free to give comments, suggestions or some better solution.

**The problem:** In Android, when i'm have uber app and google maps app installed at my device and i select **Google Maps app** always will open Uber app, i debug at the source code, and the Linking.openURL was with correct url.

**The solution:** Instead try to open _https://maps.google.com/_ and open uber app (if.i had installed), user will be asked of which map app he wants to open, it's a redundancy because he already selected google maps, however just need to select correct app (or if he wants to change, he can), and if he want to never see again, he can check "never ask me again" checkbox.


See printscreen after select google maps:

![image](https://user-images.githubusercontent.com/11881938/102632533-01d57700-412e-11eb-83ec-a0ade58139eb.png)
