### PR TITLE
Fix google maps link

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,7 @@ export function generatePrefixes(options) {
 export function prefixForGoogleMaps(alwaysIncludeGoogle) {
   return isIOS && !alwaysIncludeGoogle
     ? 'comgooglemaps://'
-    : 'https://maps.google.com/';
+    : 'https://www.google.com/maps/';
 }
 
 export function generateTitles(titles) {

--- a/src/index.js
+++ b/src/index.js
@@ -92,21 +92,18 @@ export async function showLocation(options) {
       break;
     case 'google-maps':
       // Always using universal URL instead of URI scheme since the latter doesn't support all parameters (#155)
-      url = 'https://maps.google.com/';
+      url = 'https://www.google.com/maps/dir/?api=1';
       if (useSourceDestiny) {
-        url += `?saddr=${sourceLatLng}&daddr=${latlng}`;
+        url +=`&origin=${sourceLatLng}`
+      } 
+      if (!options.googleForceLatLon && title) {
+        url += `&destination=${encodedTitle}`
       } else {
-        if (options.googleForceLatLon && title) {
-          url += `?q=loc:${lat},+${lng}+(${encodedTitle})`;
-        } else if (title) {
-          url += `?q=${encodedTitle}`;
-        } else {
-          url += `?q=${latlng}`;
-        }
+        url += `&destination=${latlng}`
       }
 
       url += options.googlePlaceId
-        ? `&query_place_id=${options.googlePlaceId}`
+        ? `&destination_place_id=${options.googlePlaceId}`
         : '';
       break;
     case 'citymapper':


### PR DESCRIPTION
Hi! 
This PR should fix issue [#138](https://github.com/flexible-agency/react-native-map-link/issues/138) with the appearance of an additional dialog on Android when user choose google maps option.
I think it happens because of using scheme 'https://maps.google.com/'.
I've edited google maps link as says in the [docs](https://developers.google.com/maps/documentation/urls/get-started#forming-the-url).
I also tested this changes on Android 9, 11 and IOS 14.4 and everything worked as expected. 

