### PR TITLE
Remove address from AppleMaps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,7 @@ export async function showLocation(options) {
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?ll=${latlng}`;
-      url += `&q=${
-        title ? encodedTitle : 'Location'
-      }`;
+      url += `&q=${title ? encodedTitle : 'Location'}`;
       break;
     case 'google-maps':
       // Always using universal URL instead of URI scheme since the latter doesn't support all parameters (#155)

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export async function showLocation(options) {
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?ll=${latlng}`;
       url += `&q=${
-        title ? `${encodedTitle}&address=${encodedTitle}` : 'Location'
+        title ? encodedTitle : 'Location'
       }`;
       break;
     case 'google-maps':


### PR DESCRIPTION
Fixes #113 

Tested on iphone X, Galaxy S8, and A51...and at least now apple maps will work with directions (but still not show the label).