### PR TITLE
Added 'directionsMode' prop to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ on their device. The app supports Apple Maps, Google Maps, Citymapper, Uber, and
 <details>
 <summary>Full list of supported apps</summary>
 
-* Apple Maps – `apple-maps`
-* Google Maps – `google-maps`
-* Citymapper – `citymapper`
-* Uber – `uber`
-* Lyft – `lyft`
-* The Transit App – `transit`
-* TruckMap – `truckmap`
-* Waze – `waze`
-* Yandex.Navi – `yandex`
-* Moovit – `moovit`
-* Yandex Taxi – `yandex-taxi`
-* Yandex Maps – `yandex-maps`
-* Kakao Map – `kakaomap`
-* Mapy.cz – `mapycz`
-* Maps.me – `maps-me`
-* OsmAnd - `osmand`
-* Gett - `gett`
-* Naver Map - `navermap`
-* 2GIS - `dgis`
-* Liftago - `liftago`
+- Apple Maps – `apple-maps`
+- Google Maps – `google-maps`
+- Citymapper – `citymapper`
+- Uber – `uber`
+- Lyft – `lyft`
+- The Transit App – `transit`
+- TruckMap – `truckmap`
+- Waze – `waze`
+- Yandex.Navi – `yandex`
+- Moovit – `moovit`
+- Yandex Taxi – `yandex-taxi`
+- Yandex Maps – `yandex-maps`
+- Kakao Map – `kakaomap`
+- Mapy.cz – `mapycz`
+- Maps.me – `maps-me`
+- OsmAnd - `osmand`
+- Gett - `gett`
+- Naver Map - `navermap`
+- 2GIS - `dgis`
+- Liftago - `liftago`
 
 </details>
 
@@ -188,7 +188,7 @@ You can do so by coping the `<queries>` statement below, and pasting it in the t
 ```
 
 If you're running into a 'unexpected element `<queries>` found in `<manifest>`' error, make sure you have an updated version of Gradle in your `android/build.gradle` file:
-  
+
 ```java
 classpath("com.android.tools.build:gradle:3.5.4")
 ```
@@ -203,7 +203,6 @@ More info [here](https://stackoverflow.com/a/67383641/1129689).
 [Read the instructions here](docs/expo.md) to make it work on iOS.
 
 </details>
-
 
 ## Usage
 
@@ -228,21 +227,20 @@ showLocation({
     naverCallerName: 'com.example.myapp' // to link into Naver Map You should provide your appname which is the bundle ID in iOS and applicationId in android.
     // appTitles: { 'google-maps': 'My custom Google Maps title' } // optionally you can override default app titles
     // app: 'uber'  // optionally specify specific app to use
+    directionsMode: 'walk' // optional, accepted values are 'car', 'walk', 'public-transport' or 'bike'
 })
 ```
 
 Notes:
 
-* The `sourceLatitude/sourceLongitude` options only work if you specify both. Currently supports all apps except Waze.
-
+- The `sourceLatitude/sourceLongitude` options only work if you specify both. Currently supports all apps except Waze.
+- Works on google-maps and apple-maps (on the latter, `bike` mode will not work). Without setting `directionsMode`, the app will decide based on his own settings.
 
 ## More information
 
-* [Using this library with Expo](docs/expo.md)
-* [Alternative usage: styled popup](docs/popup.md)
-* [Adding support for new maps apps](docs/add-app.md)
-
-
+- [Using this library with Expo](docs/expo.md)
+- [Alternative usage: styled popup](docs/popup.md)
+- [Adding support for new maps apps](docs/add-app.md)
 
 <br /><br />
 

--- a/example/App.js
+++ b/example/App.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react'
-import { Button, StyleSheet, View } from 'react-native'
+import React, {Component} from 'react';
+import {Button, StyleSheet, View} from 'react-native';
 
-import { Popup, showLocation } from 'react-native-map-link'
+import {Popup, showLocation} from 'react-native-map-link';
 
 const options = {
   latitude: 38.8976763,
@@ -9,33 +9,58 @@ const options = {
   title: 'The White House',
   dialogTitle: 'This is the dialog Title',
   dialogMessage: 'This is the amazing dialog Message',
-  cancelText: 'This is the cancel button text'
-}
+  cancelText: 'This is the cancel button text',
+};
+
+const onFootOptions = {
+  ...options,
+  sourceLatitude: 38.8991792,
+  sourceLongitude: -77.0452072,
+  directionsMode: 'walk',
+};
 
 export default class App extends Component {
-  constructor (props) {
-    super(props)
+  constructor(props) {
+    super(props);
 
     this.state = {
-      isVisible: false
-    }
+      isVisible: false,
+    };
   }
 
-  render () {
+  render() {
     return (
       <View style={styles.container}>
         <Popup
           isVisible={this.state.isVisible}
-          onCancelPressed={() => this.setState({ isVisible: false })}
-          onAppPressed={() => this.setState({ isVisible: false })}
-          onBackButtonPressed={() => this.setState({ isVisible: false })}
+          onCancelPressed={() => this.setState({isVisible: false})}
+          onAppPressed={() => this.setState({isVisible: false})}
+          onBackButtonPressed={() => this.setState({isVisible: false})}
           options={options}
         />
 
-        <Button onPress={() => showLocation(options)} title='Show in Maps using action sheet'/>
-        <Button onPress={() => { this.setState({ isVisible: true }) }} title='Show in Maps using Popup'/>
+        <View style={styles.buttonContainer}>
+          <Button
+            onPress={() => showLocation(options)}
+            title="Show in Maps using action sheet"
+          />
+        </View>
+
+        <View style={styles.buttonContainer}>
+          <Button
+            onPress={() => showLocation(onFootOptions)}
+            title="Show direction (on foot) in Maps using action sheet"
+          />
+        </View>
+
+        <Button
+          onPress={() => {
+            this.setState({isVisible: true});
+          }}
+          title="Show in Maps using Popup"
+        />
       </View>
-    )
+    );
   }
 }
 
@@ -44,6 +69,10 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#fff'
-  }
-})
+    backgroundColor: '#fff',
+    paddingHorizontal: 15,
+  },
+  buttonContainer: {
+    marginBottom: 20,
+  },
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,52 +1,55 @@
 import * as React from 'react';
-import { ViewStyle, StyleProp, ImageStyle, TextStyle } from 'react-native';
+import {ViewStyle, StyleProp, ImageStyle, TextStyle} from 'react-native';
 
 interface Options {
-    latitude: number | string
-    longitude: number | string
-    sourceLatitude?: number
-    sourceLongitude?: number
-    alwaysIncludeGoogle?: boolean
-    googleForceLatLon?: boolean
-    googlePlaceId?: string
-    title?: string
-    app?: string
-    dialogTitle?: string
-    dialogMessage?: string
-    cancelText?: string
-    appsWhiteList?: string[]
-    appTitles?: { [key: string]: string }
-    naverCallerName?: string
+  latitude: number | string;
+  longitude: number | string;
+  sourceLatitude?: number;
+  sourceLongitude?: number;
+  alwaysIncludeGoogle?: boolean;
+  googleForceLatLon?: boolean;
+  googlePlaceId?: string;
+  title?: string;
+  app?: string;
+  dialogTitle?: string;
+  dialogMessage?: string;
+  cancelText?: string;
+  appsWhiteList?: string[];
+  appTitles?: {[key: string]: string};
+  naverCallerName?: string;
+  directionsMode?: 'car' | 'walk' | 'public-transport' | 'bike';
 }
 
 interface PopupStyleProp {
-    container?: StyleProp<ViewStyle>,
-    itemContainer?: StyleProp<ViewStyle>,
-    image?: StyleProp<ImageStyle>,
-    itemText?: StyleProp<TextStyle>,
-    headerContainer?: StyleProp<ViewStyle>,
-    titleText?: StyleProp<TextStyle>,
-    subtitleText?: StyleProp<TextStyle>,
-    cancelButtonContainer?: StyleProp<ViewStyle>,
-    cancelButtonText?: StyleProp<TextStyle>,
-    separatorStyle?: StyleProp<ViewStyle>,
-    activityIndicatorContainer?: StyleProp<ViewStyle>
+  container?: StyleProp<ViewStyle>;
+  itemContainer?: StyleProp<ViewStyle>;
+  image?: StyleProp<ImageStyle>;
+  itemText?: StyleProp<TextStyle>;
+  headerContainer?: StyleProp<ViewStyle>;
+  titleText?: StyleProp<TextStyle>;
+  subtitleText?: StyleProp<TextStyle>;
+  cancelButtonContainer?: StyleProp<ViewStyle>;
+  cancelButtonText?: StyleProp<TextStyle>;
+  separatorStyle?: StyleProp<ViewStyle>;
+  activityIndicatorContainer?: StyleProp<ViewStyle>;
 }
 
 interface PopupProps {
-    isVisible: boolean,
-    showHeader?: boolean,
-    customHeader?: React.ReactNode,
-    customFooter?:  React.ReactNode,
-    onCancelPressed: () => void,
-    onBackButtonPressed: () => void,
-    onAppPressed: () => void,
-    style?: PopupStyleProp,
-    modalProps?: object,
-    options: Options,
-    appsWhiteList: string[],
-    appTitles?: { [key: string]: string }
+  isVisible: boolean;
+  showHeader?: boolean;
+  customHeader?: React.ReactNode;
+  customFooter?: React.ReactNode;
+  onCancelPressed: () => void;
+  onBackButtonPressed: () => void;
+  onAppPressed: () => void;
+  style?: PopupStyleProp;
+  modalProps?: object;
+  options: Options;
+  appsWhiteList: string[];
+  appTitles?: {[key: string]: string};
 }
 
-export function showLocation(options: Options): Promise<string | undefined | null>;
-export class Popup extends React.Component<PopupProps>{ }
+export function showLocation(
+  options: Options,
+): Promise<string | undefined | null>;
+export class Popup extends React.Component<PopupProps> {}

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import {askAppChoice, checkOptions} from './utils';
  *     appsWhiteList: array | undefined | null
  *     appTitles: object | undefined | null
  *     naverCallerName: string | undefined
+ *     directionsMode: 'car' | 'walk' | 'public-transport' | 'bike' | undefined
  * }} options
  */
 export async function showLocation(options) {
@@ -80,15 +81,53 @@ export async function showLocation(options) {
 
   let url = null;
 
+  const getDirectionsModeAppleMaps = () => {
+    switch (options.directionsMode) {
+      case 'car':
+        return 'd';
+
+      case 'walk':
+        return 'w';
+
+      case 'public-transport':
+        return 'r';
+
+      default:
+        return undefined;
+    }
+  };
+
+  const getDirectionsModeGoogleMaps = () => {
+    switch (options.directionsMode) {
+      case 'car':
+        return 'driving';
+
+      case 'walk':
+        return 'walking';
+
+      case 'public-transport':
+        return 'transit';
+
+      case 'bike':
+        return 'bicycling';
+
+      default:
+        return undefined;
+    }
+  };
+
   switch (app) {
     case 'apple-maps':
+      const appleDirectionMode = getDirectionsModeAppleMaps();
       url = prefixes['apple-maps'];
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?ll=${latlng}`;
       url += `&q=${title ? encodedTitle : 'Location'}`;
+      url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':
+      const googleDirectionMode = getDirectionsModeGoogleMaps();
       // Always using universal URL instead of URI scheme since the latter doesn't support all parameters (#155)
       url = 'https://www.google.com/maps/dir/?api=1';
       if (useSourceDestiny) {
@@ -103,6 +142,8 @@ export async function showLocation(options) {
       url += options.googlePlaceId
         ? `&destination_place_id=${options.googlePlaceId}`
         : '';
+
+      url += googleDirectionMode ? `&travelmode=${googleDirectionMode}` : '';
       break;
     case 'citymapper':
       url = `${prefixes.citymapper}directions?endcoord=${latlng}`;


### PR DESCRIPTION
Options now have a 'directionsMode' property.
Values are `car`, `walk`, `public-transport`  or `bike`

'Bike' mode doesn't work on Apple Maps.

Added example too.

Documentations:
[Apple Maps](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html#//apple_ref/doc/uid/TP40007899-CH5-SW1) (`dirflg` prop)
[Google Maps](https://developers.google.com/maps/documentation/urls/get-started#directions-action) (`travelmode` prop)

---

Fixes #152