### PR TITLE
Bugfix - Apple Maps sll Fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export async function showLocation(options) {
       url = prefixes['apple-maps'];
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
-        : `${url}?ll=${latlng}`;
+        : `${url}?sll=${latlng}`;
       url += `&q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -59,7 +59,7 @@ describe('showLocation', () => {
           longitude,
           app: 'apple-maps',
         },
-        'maps://?ll=123,234&q=Location',
+        'maps://?sll=123,234&q=Location',
       );
     });
 


### PR DESCRIPTION
# Summary
- In response to the following issue: https://github.com/flexible-agency/react-native-map-link/issues/188
- Using `sll` instead of `ll` so that it is the lat-lng that we are searching for, not the lat-lng that we are centering the map on
  - `sll` _searches_ for the lat-lng, while `ll` _centers the map_ on the lat-lng
  - source -> [Apple URL Scheme Reference](https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html)