### PR TITLE
Make appsWhiteList optional in PopupProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ interface PopupProps {
   style?: PopupStyleProp;
   modalProps?: object;
   options: Options;
-  appsWhiteList: string[];
+  appsWhiteList?: string[];
   appTitles?: {[key: string]: string};
 }
 


### PR DESCRIPTION
Application runs fine without this prop, but Typescript complains about it being missing.