### PR TITLE
Fix: Apple Maps currently searching for the `title` even though `latitude` and `longitude` are provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-map-link",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "Open the map app of the user's choice with a specific location",
   "main": "index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,7 @@ export async function showLocation(options) {
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?sll=${latlng}`;
+      !sourceLatLng &&  (url += `&q=${title ? encodedTitle : 'Location'}`);
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':

--- a/src/index.js
+++ b/src/index.js
@@ -122,8 +122,8 @@ export async function showLocation(options) {
       url = prefixes['apple-maps'];
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
-        : `${url}?sll=${latlng}`;
-      !sourceLatLng &&  (url += `&q=${title ? encodedTitle : 'Location'}`);
+        : `${url}?ll=${latlng}`;
+      url += `&q=${title ? encodedTitle : 'Location'}`
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ export async function showLocation(options) {
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?ll=${latlng}`;
-      url += `&q=${title ? encodedTitle : 'Location'}`
+      url += `&q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':

--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,6 @@ export async function showLocation(options) {
       url = useSourceDestiny
         ? `${url}?saddr=${sourceLatLng}&daddr=${latlng}`
         : `${url}?sll=${latlng}`;
-      url += `&q=${title ? encodedTitle : 'Location'}`;
       url += appleDirectionMode ? `&dirflg=${appleDirectionMode}` : '';
       break;
     case 'google-maps':

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -59,7 +59,7 @@ describe('showLocation', () => {
           longitude,
           app: 'apple-maps',
         },
-        'maps://?sll=123,234&q=Location',
+        'maps://?ll=123,234&q=Location',
       );
     });
 


### PR DESCRIPTION
Changing the search from using `sll` to use only `ll` as correctly pointed out here #222 
According to apple docs `sll` will be used to determine the area where a search will be performed where, `ll`
 will be used for centering upon a search. 

These are two very different use cases, where `ll` is the appropriate method when we are using the `showLocation` option. 
To achieve a behavior similar to what `sll` provides we might want to have a new exported function from the lib since it is a different case.
https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/MapLinks/MapLinks.html